### PR TITLE
Update for Fondant 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fondant==0.6.2
+fondant==0.7.0
 notebook==7.0.6

--- a/src/pipeline.ipynb
+++ b/src/pipeline.ipynb
@@ -134,7 +134,7 @@
    "source": [
     "from pathlib import Path\n",
     "\n",
-    "from fondant.pipeline import ComponentOp, Pipeline\n",
+    "from fondant.pipeline import ComponentOp, Pipeline, Resources\n",
     "\n",
     "BASE_PATH = \"./data_dir\"\n",
     "Path(BASE_PATH).mkdir(parents=True, exist_ok=True)\n",
@@ -257,8 +257,10 @@
     "        \"batch_size\": 8,\n",
     "        \"max_new_tokens\": 50,\n",
     "    },\n",
-    "   number_of_accelerators=number_of_accelerators,\n",
-    "   accelerator_name=accelerator_name,\n",
+    "    resources=Resources(\n",
+    "        accelerator_number=number_of_accelerators,\n",
+    "        accelerator_name=accelerator_name,\n",
+    "    ),\n",
     ")\n",
     "\n",
     "segment_images_op = ComponentOp.from_registry(\n",
@@ -267,8 +269,10 @@
     "        \"model_id\": \"openmmlab/upernet-convnext-small\",\n",
     "        \"batch_size\": 8,\n",
     "    },\n",
-    "    number_of_accelerators=number_of_accelerators,\n",
-    "    accelerator_name=accelerator_name,\n",
+    "    resources=Resources(\n",
+    "        accelerator_number=number_of_accelerators,\n",
+    "        accelerator_name=accelerator_name,\n",
+    "    ),\n",
     ")"
    ]
   },
@@ -293,9 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Optional: writing the dataset to the Hugging Face Hub "
    ]
@@ -450,10 +452,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fondant.compiler import DockerCompiler\n",
-    "from fondant.runner import DockerRunner\n",
-    "\n",
-    "from pathlib import Path\n",
+    "from fondant.pipeline.compiler import DockerCompiler\n",
+    "from fondant.pipeline.runner import DockerRunner\n",
     "\n",
     "DockerCompiler().compile(pipeline=pipeline, output_path=\"docker-compose.yml\")\n",
     "DockerRunner().run(\"docker-compose.yml\")"
@@ -479,7 +479,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fondant.explorer import run_explorer_app\n",
+    "from fondant.explore import run_explorer_app\n",
     "\n",
     "run_explorer_app(\n",
     "    base_path=BASE_PATH,\n",


### PR DESCRIPTION
I already published Fondant 0.7.0 to test.pypi so we can upgrade our examples and test them against it (which I did). The main change is the split of the component and pipeline SDKs.